### PR TITLE
Implement psx build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,21 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
+  build-psx:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: wine
+      run: sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install wine32
+
+    - name: psy-q
+      run: git clone https://github.com/sozud/psyq_sdk.git
+
+    - name: Build
+      run: cd psx_seq_player/build && pip3 install -r requirements.txt && python3 build.py --psyq_path ../../psyq_sdk
+
   build-windows:
     runs-on: windows-latest
 

--- a/psx_seq_player/.gitignore
+++ b/psx_seq_player/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+.ninja_deps
+.ninja_log
+build.ninja
+obj
+build/objlib

--- a/psx_seq_player/Sound.hpp
+++ b/psx_seq_player/Sound.hpp
@@ -4,7 +4,11 @@
 #include "lib_snd.hpp"
 #include "lib_spu.hpp"
 #include "psx_stubs.hpp"
+#ifdef PSX
+#include <STDIO.H>
+#else
 #include <stdio.h>
+#endif
 
 #define MVOL 127
 #define SVOL 64

--- a/psx_seq_player/build/build.py
+++ b/psx_seq_player/build/build.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+import glob
+import argparse
+import sys
+import os
+import time
+import subprocess
+import re
+import tempfile
+import platform
+from shutil import which
+from ninja import BIN_DIR
+# local copy as the pip version doesn't have dyndeps in build() func
+import ninja_syntax
+
+os.environ['WINEDEBUG'] = '-all'
+os.environ['TMPDIR'] = tempfile.gettempdir()
+
+has_wine = bool(which('wine'))
+has_wibo = bool(which('wibo'))
+has_cpp = bool(which('cpp'))
+
+# Native preprocesor doesn't work under WSL
+if "microsoft-standard" in platform.uname().release:
+    has_cpp = False
+
+# TODO: make r3000.h and asm.h case sensitive symlinks on linux
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='MGS Ninja build script generator')
+
+    # Optional
+    parser.add_argument('--psyq_path', type=str, default=os.environ.get("PSYQ_SDK") or "../../psyq_sdk",
+                        help='Path to the root of the cloned PSYQ repo')
+
+    args = parser.parse_args()
+
+    args.psyq_path = os.path.relpath(args.psyq_path).replace("\\","/")
+    args.obj_directory = 'obj'
+    args.defines = []
+    print("psyq_path = " + args.psyq_path)
+    return args
+
+def prefix(pfx, cmd):
+    if pfx == "wibo" and has_wibo:
+        return f"wibo {cmd}"
+    if has_wine:
+        return f"wine {cmd}"
+    return cmd
+
+def ninja_run():
+    ninja = os.path.join(BIN_DIR, 'ninja')
+    ninja_args = [] # TODO: pass through args to ninja?
+    return subprocess.call([ninja, "--verbose"] + ninja_args)
+
+args = parse_arguments()
+
+f = open("build.ninja", "w")
+ninja = ninja_syntax.Writer(f)
+
+ninja.variable("psyq_path", args.psyq_path)
+ninja.newline()
+
+ninja.variable("psyq_path_backslashed", args.psyq_path.replace('/', '\\'))
+ninja.newline()
+
+ninja.variable("psyq_asmpsx_44_exe", prefix("wibo", "$psyq_path/psyq_4.4/bin/asmpsx.exe"))
+ninja.newline()
+
+preprocessor_defines = ' '.join(f'-D{define}' for define in args.defines)
+
+if has_cpp:
+    ninja.variable("psyq_c_preprocessor_44_exe", f"cpp -nostdinc {preprocessor_defines}")
+else:
+    ninja.variable("psyq_c_preprocessor_44_exe", prefix("wine", f"$psyq_path/psyq_4.4/bin/CPPPSX.exe {preprocessor_defines}"))
+ninja.newline()
+
+ninja.variable("psyq_cc_44_exe", prefix("wine", "$psyq_path/psyq_4.4/bin/CC1PLPSX.EXE"))
+ninja.newline()
+
+ninja.variable("psyq_aspsx_44_exe", prefix("wibo", "$psyq_path/psyq_4.4/bin/aspsx.exe"))
+ninja.newline()
+
+ninja.variable("psyq_psylink_exe", prefix("wibo", "$psyq_path/psyq_4.4/bin/psylink.exe"))
+ninja.newline()
+
+ninja.variable("src_dir", "..")
+ninja.newline()
+
+# /l = produce linkable output file
+# /q = run quietly
+ninja.rule("psyq_asmpsx_assemble", "$psyq_asmpsx_44_exe /l /q $in,$out", "Assemble $in -> $out")
+ninja.newline()
+
+includes = "-I " + args.psyq_path + "/psyq_4.4/INCLUDE" + " -I $src_dir"
+
+ninja.rule("psyq_c_preprocess_44", "$psyq_c_preprocessor_44_exe -undef -DPSX -D__GNUC__=2 -D__OPTIMIZE__ " + includes + " -lang-c -Dmips -D__mips__ -D__mips -Dpsx -D__psx__ -D__psx -D_PSYQ -D__EXTENSIONS__ -D_MIPSEL -D__CHAR_UNSIGNED__ -D_LANGUAGE_C -D__cplusplus -D_LANGUAGE_C_PLUS_PLUS $in $out", "Preprocess $in -> $out")
+ninja.newline()
+
+# generate header deps, adds edges to the build graph for the next build -M option will write header deps
+ninja.rule("psyq_c_preprocess_44_headers", "$psyq_c_preprocessor_44_exe -M -undef -DPSX -D_LANGUAGE_C_PLUS_PLUS -D__cplusplus -D__GNUC__=2 -D__OPTIMIZE__ " + includes + " -lang-c -Dmips -D__mips__ -D__mips -Dpsx -D__psx__ -D__psx -D_PSYQ -D__EXTENSIONS__ -D_MIPSEL -D__CHAR_UNSIGNED__  $in $out", "Preprocess for includes $in -> $out")
+ninja.newline()
+
+ninja.rule("header_deps", f"{sys.executable} hash_include_msvc_formatter.py $in $out", "Include deps fix $in -> $out", deps="msvc")
+ninja.newline()
+
+ninja.rule("asm_include_preprocess_44", f"{sys.executable} include_asm_preprocess.py $in $out", "Include asm preprocess $in -> $out")
+ninja.newline()
+
+ninja.rule("asm_include_postprocess", f"{sys.executable} include_asm_fixup.py $in $out", "Include asm postprocess $in -> $out")
+ninja.newline()
+
+ninja.variable("gSize", "8")
+ninja.newline()
+
+ninja.rule("psyq_cc_44", "$psyq_cc_44_exe -quiet -O2 -w -G $gSize -g -Wall $in -o $out""", "Compile $in -> $out")
+ninja.newline()
+
+ninja.rule("psyq_aspsx_assemble_44", "$psyq_aspsx_44_exe -q $in -o $out", "Assemble $in -> $out")
+ninja.newline()
+
+ninja.rule("linker_command_file_preprocess", f"{sys.executable} linker_command_file_preprocess.py $in $psyq_sdk $out {' '.join(args.defines)} $overlay $overlay_suffix", "Preprocess $in -> $out")
+ninja.newline()
+
+psqy_lib = f'{args.psyq_path}/psyq_4.4/LIB'
+
+ninja.rule("psylink", f"$psyq_psylink_exe /l {psqy_lib} /c /n 4000 /q /gp .sdata /m @\"../{args.obj_directory}/linker_command_file$suffix.txt\",../{args.obj_directory}/sound$suffix.cpe,../{args.obj_directory}/asm$suffix.sym,../{args.obj_directory}/asm$suffix.map", "Link $out")
+
+# TODO: update the tool so we can set the output name optionally
+# cmd /c doesn't like forward slashed relative paths
+ninja.rule("cpe2exe", prefix("wine", "cmd /c \"$psyq_path_backslashed\\psyq_4.3\\bin\\cpe2exe.exe -CJ $in > NUL\""), "cpe2exe $in -> $out")
+ninja.newline()
+
+def create_psyq_ini(sdkDir, psyqDir):
+    data = ""
+    with open(sdkDir + "/" + psyqDir + "/bin/psyq.ini.template", 'r') as file:
+        data = file.read()
+    data = data.replace("$PSYQ_PATH", sdkDir + "/" + psyqDir)
+    data = data.replace("/", "\\")
+    ini_file = open(sdkDir + "/" + psyqDir + "/bin/psyq.ini", "w")
+    ini_file.write(data)
+
+def init_psyq_ini_files(sdkDir):
+    create_psyq_ini(sdkDir, "psyq_4.3")
+    create_psyq_ini(sdkDir, "psyq_4.4")
+
+def get_files_recursive(path, ext):
+    collectedFiles = []
+    # r=root, d=directories, f = files
+    for r, d, f in os.walk(path):
+        for file in f:
+            if file.endswith(ext):
+                collectedFiles.append(os.path.join(r, file))
+    return collectedFiles
+
+def gen_build_target(targetName):
+    ninja.comment("Build target " + targetName)
+
+    asmFiles = get_files_recursive("../asm", ".s")
+    print("Got " + str(len(asmFiles)) + " asm files")
+
+    cFiles = ['../vs_vt.c', '../vs_vtc.c', '../main.cpp', '../lib_snd.cpp', '../lib_spu.cpp']
+    print("Got " + str(len(cFiles)) + " source files")
+
+    linkerDeps = []
+
+    # TODO: Use the correct toolchain and -G flag for each c file
+    # TODO: .h file deps of .c files
+
+    # build .s files
+    for asmFile in asmFiles:
+        asmFile = asmFile.replace("\\", "/")
+        asmOFile = asmFile.replace("/asm/", f"/{args.obj_directory}/")
+        asmOFile = asmOFile.replace(".s", ".obj")
+        #print("Build step " + asmFile + " -> " + asmOFile)
+        ninja.build(asmOFile, "psyq_asmpsx_assemble", asmFile)
+        linkerDeps.append(asmOFile)
+
+    # build .c files
+    for cFile in cFiles:
+        cFile = cFile.replace("\\", "/")
+        cOFile = cFile.replace("../", f"../{args.obj_directory}/")
+
+        if 'cpp' in cFile:
+            cPreProcHeadersFile = cOFile.replace(".cpp", ".cpp.preproc.headers")
+            cPreProcHeadersFixedFile = cOFile.replace(".cpp", ".cpp.preproc.headers_fixed")
+            cConvertedFile = cOFile.replace(".cpp", ".cpp.eucjp")
+            cPreProcFile = cOFile.replace(".cpp", ".cpp.preproc")
+            cDynDepFile = cOFile.replace(".cpp", ".cpp.dyndep")
+            cAsmPreProcFile = cOFile.replace(".cpp", ".cpp.asm.preproc")
+            cAsmPreProcFileDeps = cOFile.replace(".cpp", ".cpp.asm.preproc.deps")
+            cAsmFile = cOFile.replace(".cpp", ".asm")
+            cTempOFile = cOFile.replace(".cpp", ".cpp.fixme.obj")
+            cOFile = cOFile.replace(".cpp", ".obj")
+        else:
+            cPreProcHeadersFile = cOFile.replace(".c", ".c.preproc.headers")
+            cPreProcHeadersFixedFile = cOFile.replace(".c", ".c.preproc.headers_fixed")
+            cConvertedFile = cOFile.replace(".c", ".c.eucjp")
+            cPreProcFile = cOFile.replace(".c", ".c.preproc")
+            cDynDepFile = cOFile.replace(".c", ".c.dyndep")
+            cAsmPreProcFile = cOFile.replace(".c", ".c.asm.preproc")
+            cAsmPreProcFileDeps = cOFile.replace(".c", ".c.asm.preproc.deps")
+            cAsmFile = cOFile.replace(".c", ".asm")
+            cTempOFile = cOFile.replace(".c", ".c.fixme.obj")
+            cOFile = cOFile.replace(".c", ".obj")
+        #print("Build step " + asmFile + " -> " + asmOFile)
+
+        ninja.build(cPreProcHeadersFile, "psyq_c_preprocess_44_headers", cFile)
+        ninja.build(cPreProcHeadersFixedFile, "header_deps", cPreProcHeadersFile)
+
+        compiler = "psyq_cc_44"
+        aspsx = "psyq_aspsx_assemble_44"
+        ninja.build(cPreProcFile, "psyq_c_preprocess_44", cFile, implicit=[cPreProcHeadersFixedFile])
+        ninja.build([cAsmPreProcFile, cAsmPreProcFileDeps, cDynDepFile], "asm_include_preprocess_44", cPreProcFile)
+        ninja.build(cAsmFile, compiler, cAsmPreProcFile)
+        ninja.build(cTempOFile, aspsx, cAsmFile)
+        ninja.build(cOFile, "asm_include_postprocess", cTempOFile, implicit=[cAsmPreProcFileDeps, cDynDepFile], dyndep=cDynDepFile)
+
+        linkerDeps.append(cOFile)
+
+    # Build main exe
+
+    # preprocess linker_command_file.txt
+    linkerCommandFile = f"../{args.obj_directory}/linker_command_file.txt"
+    ninja.build(linkerCommandFile, "linker_command_file_preprocess", f"linker_command_file.txt", variables={'psyq_sdk': args.psyq_path})
+    ninja.newline()
+
+    # run the linker to generate the cpe
+    cpeFile = f"../{args.obj_directory}/sound.cpe"
+    ninja.build(cpeFile, "psylink", implicit=linkerDeps + [linkerCommandFile])
+    ninja.newline()
+
+    # cpe to exe
+    exeFile = f"../{args.obj_directory}/sound.exe"
+    ninja.build(exeFile, "cpe2exe", cpeFile)
+    ninja.newline()
+
+gen_build_target("psx_seq_player")
+
+f.close()
+
+time_before = time.time()
+exit_code = ninja_run()
+took = time.time() - time_before
+print(f'build took {took:.2f} seconds')
+
+sys.exit(exit_code)

--- a/psx_seq_player/build/hash_include_msvc_formatter.py
+++ b/psx_seq_player/build/hash_include_msvc_formatter.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+def main(path, output):
+    with open(path) as f:
+        lines = f.readlines()
+
+    with open(output, 'w') as f:
+        for raw_line in lines:
+            line = raw_line.strip()
+            # change C:\blah.obj : C:\foo.h \ to just C:\foo.h \
+            pos = line.find(":", 3)
+            if pos != -1:
+                line = line[pos+1:]
+            if line.endswith(" \\"):
+                line = line[:-2]
+            line = line.replace('\\', '/')
+            line = line.strip()
+            if len(line) > 0:
+                # ignore psyq headers
+                if '4.4' not in line and '4.3' not in line:
+                    line = line.replace('\\ ', '|SPACE|')
+                    includes = line.split(' ')
+                    for include in includes:
+                        include = include.replace('|SPACE|', ' ')
+                        print("Note: including file: " + include)
+                        f.write(include + '\n')
+
+if __name__ == '__main__':
+    src = sys.argv[1].replace('\\', '/')
+    dst = sys.argv[2].replace('\\', '/')
+    #src= "C:\\data\\mgs_reversing\\obj\\anime.c.preproc.headers"
+    #dst= "C:\\data\\mgs_reversing\\obj\\anime.c.preproc.headers_fixed" 
+    main(src, dst)

--- a/psx_seq_player/build/include_asm_fixup.py
+++ b/psx_seq_player/build/include_asm_fixup.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+import sys
+import struct
+from objlib import get_obj_funcs
+import shutil
+
+def disasm(code, addr):
+    from capstone import Cs, CS_ARCH_MIPS, CS_MODE_MIPS32
+    md = Cs(CS_ARCH_MIPS, CS_MODE_MIPS32)
+    for i in md.disasm(code, addr):
+        print('0x{:x}:\t{}\t{}'.format(i.address, i.mnemonic, i.op_str))
+
+def hexdump(data):
+    return ' '.join([f'{x:02X}' for x in data])
+
+def obj_with_name(deps, toFind):
+    for obj in deps:
+        if toFind in obj:
+            return obj
+    return None
+
+def fix_obj(obj_to_fix, output_obj, deps):
+    code_start = 0x800148B8
+    psyq_start = 0x8008C608
+
+    fixed_funcs = 0
+    for old_name, segments in get_obj_funcs(obj_to_fix):
+        code = b''.join([x[1] for x in segments])
+        # only INCLUDE_ASM funcs start with a nop
+        if code.startswith(b'\x00\x00\x00\x00'):
+            # last 12 bytes is a return instruction encoded with the address of asm to include
+            return_instructions = code[-12:]
+
+            hi = struct.unpack('<H', return_instructions[0:2])[0] << 16
+            lo = struct.unpack('<H', return_instructions[8:10])[0]
+            addr_num = hi + lo
+            overwritten_name_char = addr_num >> 24
+            addr_num = (addr_num & 0x00FFFFFF) | (0x80 << 24)
+
+            name = old_name
+            name_chars = bytearray(name)
+            name_chars[0] = overwritten_name_char
+            name = bytes(name_chars)
+
+            source_obj = obj_with_name(deps, name.decode() + '.obj')
+            if not source_obj:
+                print('couldnt find source obj with name:', name.decode() )
+                continue
+
+            source_funcs = get_obj_funcs(source_obj)
+            # all of our .s files should have a single xdef
+            assert len(source_funcs) == 1
+            # assume funcs in .s files aren't split across code blocks
+            assert len(source_funcs[0][1]) == 1, source_funcs[0]
+            source_code = b''.join([x[1] for x in source_funcs[0][1]])
+
+            if len(code) != len(source_code):
+                print('error: size mismatch! trying to import capstone for debugging..')
+                print(name)
+                print('dummy func:')
+                disasm(code, addr_num)
+                print('orig func:')
+                disasm(source_code, addr_num)
+                raise Exception('code size mismatch: {} {} {}'.format(addr_num, len(code),
+                    len(source_code)))
+
+            with open(obj_to_fix, 'r+b') as f:
+                # write the code
+                i = 0
+                for file_pos, segment_code in segments:
+                    l = len(segment_code)
+                    f.seek(file_pos)
+                    code = source_code[i:i+l]
+                    f.write(code)
+                    i += l
+
+                # now replace every occurance of the name
+                f.seek(0)
+                data = f.read()
+                assert old_name in data
+                data = data.replace(old_name, name)
+                f.seek(0)
+                f.write(data)
+
+            fixed_funcs += 1
+
+    # EL hacko - copy input to output obj
+    shutil.copy2(obj_to_fix, output_obj)
+
+    # if fixed_funcs > 0:
+    #     print(f'Fixed {fixed_funcs} IMPORT_ASM funcs in obj:', obj_to_fix)
+
+def main(input_obj, output_obj, deps_file):
+    deps = []
+    with open(deps_file) as f:
+        deps = ['../' + line.rstrip() for line in f if len(line) > 1]
+    if len(deps) == 0:
+        shutil.copy2(input_obj, output_obj)
+    else:
+        fix_obj(input_obj, output_obj, deps)
+
+if __name__ == '__main__':
+    src = sys.argv[1].replace('\\', '/')
+    dst = sys.argv[2].replace('\\', '/')
+    if 'cpp' in src:
+        deps = dst.replace('.obj', '.cpp.asm.preproc.deps')
+    else:
+        deps = dst.replace('.obj', '.c.asm.preproc.deps')
+    main(src, dst, deps)

--- a/psx_seq_player/build/include_asm_preprocess.py
+++ b/psx_seq_player/build/include_asm_preprocess.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+import os
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+RETURN_SIZE = 12 # just the return
+NOP_SIZE = 4
+
+# #pragma INCLUDE_ASM("asm/chara/snake/sna_800515BC.s");
+PRAGMA_RE = r'^#pragma\s+INCLUDE_ASM\s*\(\s*"([^"]+)"\s*\).*$'
+
+# all on one line to keep error line numbers correct
+FUNC_FMT = r'int {}(void) {{ asm("{}"); return {}; }}'
+
+# _800515BC.
+ADDR_SUFFIX_RE = r'_([0-9A-F]{8})\.'
+
+TMP_DIR = 'include_asm_tmp'
+
+def main(path, output):
+    with open(path, encoding='utf8') as f:
+        lines = f.readlines()
+
+    processed = []
+    depends = []
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line.startswith('#pragma'):
+            processed.append(raw_line)
+            continue
+
+        m = re.match(PRAGMA_RE, line)
+        if not m:
+            processed.append(raw_line)
+            continue
+
+        include_path = m.group(1)
+
+        if '\\' in include_path:
+            print("error: INCLUDE_ASM paths should not use backslashes in: ", include_path, file=sys.stderr)
+            sys.exit(1)
+
+        m = re.search(ADDR_SUFFIX_RE, include_path)
+        if not m:
+            print('error: INCLUDE_ASM paths should have the _<ADDR>.s suffix', file=sys.stderr)
+            sys.exit(2)
+
+        addr_str = m.group(1)
+        addr = int(addr_str, 16)
+
+        func_size = open(os.path.join('..', include_path), 'r').read().count('dw 0x') * 4
+
+        if func_size < RETURN_SIZE + NOP_SIZE:
+            print('error: INCLUDE_ASM func too small - consider matching it: ', addr_str, file=sys.stderr)
+            sys.exit(5)
+
+        num_nops = func_size - RETURN_SIZE
+        assert num_nops % NOP_SIZE == 0
+        nops = 'nop;' * int(num_nops / NOP_SIZE)
+
+        name = os.path.basename(include_path).replace('.s', '')
+
+        first_char = ord(name[0])
+
+        upper_byte = addr >> 24
+        assert upper_byte == 0x80
+
+        # we need to temporarily rename the func without changing its size so
+        # encode first char of name into 0x80 part of addr since that's constant for us
+        addr = (addr & 0x00FFFFFF) | (first_char << 24)
+
+        name_chars = list(name)
+        name_chars[0] = '_'
+        name = ''.join(name_chars)
+
+        func = FUNC_FMT.format(name, nops, hex(addr)) + '\n'
+        processed.append(func)
+        depends.append(include_path.replace('.s', '.obj').replace('asm/', 'obj/'))
+
+    with open(output, 'w', encoding='utf8') as f:
+        f.write(''.join(processed))
+
+    with open(output + '.deps', 'w') as f:
+        f.write('\n'.join(depends) + '\n')
+
+    # nina picks this up due to deps=msvc which ensures the post process
+    # will only run after these required objs are built
+    #for d in depends:
+    #    print("Note: including file: " + os.path.abspath(d))
+    #print("output = " + output)
+
+    if ".cpp" in output:
+        dynDepName = output.replace(".cpp.asm.preproc", ".cpp.dyndep")
+        targetAddTo = output.replace(".cpp.asm.preproc", ".obj")
+    else:
+        dynDepName = output.replace(".c.asm.preproc", ".c.dyndep")
+        targetAddTo = output.replace(".c.asm.preproc", ".obj")
+    #print("Dyndep file = " + dynDepName)
+
+    targetAddTo = targetAddTo.replace(":", "$:") # escape colon in drive path
+    #print("targetAddTo = " + targetAddTo)
+
+    with open(dynDepName, 'w') as f:
+        f.write("ninja_dyndep_version = 1\n")
+        depsStr = ""
+        if len(depends) > 0:
+            for d in depends:
+                d = '../' + d
+                d = d.replace("\\", "/")
+                d = d.replace(":", "$:") # escape colon in drive path
+                depsStr = depsStr + " " + d
+            f.write("build " + targetAddTo + ": dyndep | " + depsStr + "\n")
+        else:
+            f.write("build " + targetAddTo + ": dyndep" + depsStr + "\n")
+
+if __name__ == '__main__':
+    src = sys.argv[1].replace('\\', '/')
+    dst = sys.argv[2].replace('\\', '/')
+    main(src, dst)

--- a/psx_seq_player/build/linker_command_file.txt
+++ b/psx_seq_player/build/linker_command_file.txt
@@ -1,0 +1,22 @@
+	org     $80010000
+
+	include "../obj/main.obj"
+	;include "seqplayer.obj"
+	include "../obj/lib_snd.obj"
+	include "../obj/lib_spu.obj"
+	include "../obj/vs_vtc.obj"
+	include "../obj/vs_vt.obj"
+
+	inclib libsn.lib
+	inclib libds.lib
+	inclib libapi.lib
+	inclib libgpu.lib
+
+	inclib libcd.lib
+	inclib libgs.lib
+	inclib libc.lib
+	inclib libetc.lib
+	inclib libgte.lib
+
+	regs    pc=__SN_ENTRY_POINT
+

--- a/psx_seq_player/build/linker_command_file_preprocess.py
+++ b/psx_seq_player/build/linker_command_file_preprocess.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+from os.path import dirname, basename
+from jinja2 import Environment, FileSystemLoader
+
+def process_flag(flag):
+    # Either "KEY=VALUE":
+    kv = re.match(r'^([A-Z_]+)=(.*)$', flag)
+    if kv:
+        return (kv.group(1), kv.group(2))
+    else:
+        # Just a "FLAG":
+        return (flag, True)
+
+def main(path, psyq_sdk, output, flags):
+    env = Environment(loader=FileSystemLoader(dirname(path)))
+    flags = dict(process_flag(flag) for flag in flags)
+
+    with open(output, 'w') as f:
+        template = env.get_template(basename(path))
+        processed = template.render(OBJ_DIR=dirname(output), PSYQ_SDK=psyq_sdk, **flags)
+        f.write(processed)
+
+if __name__ == '__main__':
+    src = sys.argv[1]
+    psyq_sdk = sys.argv[2]
+    dst = sys.argv[3]
+    flags = sys.argv[4:]
+    main(src, psyq_sdk, dst, flags)

--- a/psx_seq_player/build/ninja_syntax.py
+++ b/psx_seq_player/build/ninja_syntax.py
@@ -1,0 +1,199 @@
+#!/usr/bin/python
+
+# Copyright 2011 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python module for generating .ninja files.
+
+Note that this is emphatically not a required piece of Ninja; it's
+just a helpful utility for build-file-generation systems that already
+use Python.
+"""
+
+import re
+import textwrap
+
+def escape_path(word):
+    return word.replace('$ ', '$$ ').replace(' ', '$ ').replace(':', '$:')
+
+class Writer(object):
+    def __init__(self, output, width=78):
+        self.output = output
+        self.width = width
+
+    def newline(self):
+        self.output.write('\n')
+
+    def comment(self, text):
+        for line in textwrap.wrap(text, self.width - 2, break_long_words=False,
+                                  break_on_hyphens=False):
+            self.output.write('# ' + line + '\n')
+
+    def variable(self, key, value, indent=0):
+        if value is None:
+            return
+        if isinstance(value, list):
+            value = ' '.join(filter(None, value))  # Filter out empty strings.
+        self._line('%s = %s' % (key, value), indent)
+
+    def pool(self, name, depth):
+        self._line('pool %s' % name)
+        self.variable('depth', depth, indent=1)
+
+    def rule(self, name, command, description=None, depfile=None,
+             generator=False, pool=None, restat=False, rspfile=None,
+             rspfile_content=None, deps=None):
+        self._line('rule %s' % name)
+        self.variable('command', command, indent=1)
+        if description:
+            self.variable('description', description, indent=1)
+        if depfile:
+            self.variable('depfile', depfile, indent=1)
+        if generator:
+            self.variable('generator', '1', indent=1)
+        if pool:
+            self.variable('pool', pool, indent=1)
+        if restat:
+            self.variable('restat', '1', indent=1)
+        if rspfile:
+            self.variable('rspfile', rspfile, indent=1)
+        if rspfile_content:
+            self.variable('rspfile_content', rspfile_content, indent=1)
+        if deps:
+            self.variable('deps', deps, indent=1)
+
+    def build(self, outputs, rule, inputs=None, implicit=None, order_only=None,
+              variables=None, implicit_outputs=None, pool=None, dyndep=None):
+        outputs = as_list(outputs)
+        out_outputs = [escape_path(x) for x in outputs]
+        all_inputs = [escape_path(x) for x in as_list(inputs)]
+
+        if implicit:
+            implicit = [escape_path(x) for x in as_list(implicit)]
+            all_inputs.append('|')
+            all_inputs.extend(implicit)
+        if order_only:
+            order_only = [escape_path(x) for x in as_list(order_only)]
+            all_inputs.append('||')
+            all_inputs.extend(order_only)
+        if implicit_outputs:
+            implicit_outputs = [escape_path(x)
+                                for x in as_list(implicit_outputs)]
+            out_outputs.append('|')
+            out_outputs.extend(implicit_outputs)
+
+        self._line('build %s: %s' % (' '.join(out_outputs),
+                                     ' '.join([rule] + all_inputs)))
+        if pool is not None:
+            self._line('  pool = %s' % pool)
+        if dyndep is not None:
+            self._line('  dyndep = %s' % dyndep)
+
+        if variables:
+            if isinstance(variables, dict):
+                iterator = iter(variables.items())
+            else:
+                iterator = iter(variables)
+
+            for key, val in iterator:
+                self.variable(key, val, indent=1)
+
+        return outputs
+
+    def include(self, path):
+        self._line('include %s' % path)
+
+    def subninja(self, path):
+        self._line('subninja %s' % path)
+
+    def default(self, paths):
+        self._line('default %s' % ' '.join(as_list(paths)))
+
+    def _count_dollars_before_index(self, s, i):
+        """Returns the number of '$' characters right in front of s[i]."""
+        dollar_count = 0
+        dollar_index = i - 1
+        while dollar_index > 0 and s[dollar_index] == '$':
+            dollar_count += 1
+            dollar_index -= 1
+        return dollar_count
+
+    def _line(self, text, indent=0):
+        """Write 'text' word-wrapped at self.width characters."""
+        leading_space = '  ' * indent
+        while len(leading_space) + len(text) > self.width:
+            # The text is too wide; wrap if possible.
+
+            # Find the rightmost space that would obey our width constraint and
+            # that's not an escaped space.
+            available_space = self.width - len(leading_space) - len(' $')
+            space = available_space
+            while True:
+                space = text.rfind(' ', 0, space)
+                if (space < 0 or
+                    self._count_dollars_before_index(text, space) % 2 == 0):
+                    break
+
+            if space < 0:
+                # No such space; just use the first unescaped space we can find.
+                space = available_space - 1
+                while True:
+                    space = text.find(' ', space + 1)
+                    if (space < 0 or
+                        self._count_dollars_before_index(text, space) % 2 == 0):
+                        break
+            if space < 0:
+                # Give up on breaking.
+                break
+
+            self.output.write(leading_space + text[0:space] + ' $\n')
+            text = text[space+1:]
+
+            # Subsequent lines are continuations, so indent them.
+            leading_space = '  ' * (indent+2)
+
+        self.output.write(leading_space + text + '\n')
+
+    def close(self):
+        self.output.close()
+
+
+def as_list(input):
+    if input is None:
+        return []
+    if isinstance(input, list):
+        return input
+    return [input]
+
+
+def escape(string):
+    """Escape a string such that it can be embedded into a Ninja file without
+    further interpretation."""
+    assert '\n' not in string, 'Ninja syntax does not allow newlines'
+    # We only have one special metacharacter: '$'.
+    return string.replace('$', '$$')
+
+
+def expand(string, vars, local_vars={}):
+    """Expand a string containing $vars as Ninja would.
+
+    Note: doesn't handle the full Ninja variable syntax, but it's enough
+    to make configure.py's use of it work.
+    """
+    def exp(m):
+        var = m.group(1)
+        if var == '$':
+            return '$'
+        return local_vars.get(var, vars.get(var, ''))
+    return re.sub(r'\$(\$|\w*)', exp, string)

--- a/psx_seq_player/build/objlib/__init__.py
+++ b/psx_seq_player/build/objlib/__init__.py
@@ -1,0 +1,1 @@
+from .obj import get_obj_funcs

--- a/psx_seq_player/build/objlib/obj.py
+++ b/psx_seq_player/build/objlib/obj.py
@@ -1,0 +1,209 @@
+import struct
+import sys
+
+# psyq obj parser with one purpose: get the names, offsets, sizes, and bytes of all funcs
+def get_obj_funcs(path):
+    pos = 0
+    current_section = None
+    text_section = None
+    code_blocks = []
+    code_block_pos = 0
+    xdefs = []
+
+    def u8():
+        nonlocal pos
+        ret = data[pos]
+        pos = pos + 1
+        return ret
+
+    def u16():
+        nonlocal pos
+        ret = struct.unpack('<H', data[pos:pos+2])[0]
+        pos = pos + 2
+        return ret
+
+    def u32():
+        nonlocal pos
+        ret = struct.unpack('<I', data[pos:pos+4])[0]
+        pos = pos + 4
+        return ret
+
+    def b(num):
+        nonlocal pos
+        ret = data[pos:pos+num]
+        pos = pos + num
+        return ret
+
+    def patch():
+        nonlocal pos
+        blah = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24]
+        a = u8()
+        if a == 0:
+            pos += 4
+            return
+        elif a in blah:
+            pos += 2
+            return
+        patch()
+        patch()
+
+    with open(path, 'rb') as f:
+        data = f.read()
+
+    if b(3) != b'LNK':
+        print('bad header')
+        sys.exit(1)
+
+    if u8() != 2:
+        print('bad version')
+        sys.exit(2)
+
+    while pos < len(data):
+        cmd = u8()
+
+        if cmd == 0:
+            # print('eof')
+            break
+        elif cmd == 2: # code
+            assert current_section is not None
+            code_len = u16()
+            code = b(code_len)
+            if current_section == text_section:
+                code_blocks.append((code_block_pos, code, pos - code_len))
+                code_block_pos += code_len
+        elif cmd == 6:
+            current_section = u16()
+        elif cmd == 8:
+            pos += 4
+        elif cmd == 10:
+            pos += 1 + 2
+            patch()
+        elif cmd == 12: # xdef
+            pos += 2
+            section = u16()
+            offset = u32()
+            xdef_name_len = u8()
+            xdef_name = b(xdef_name_len)
+            if section == text_section:
+                xdefs.append((offset, xdef_name))
+                # print('xdef', xdef_name, offset)
+        elif cmd == 14:
+            pos += 2
+            c = u8()
+            pos += c
+        elif cmd == 16: # section def
+            section = u16()
+            pos += 2 + 1
+            section_name_len = u8()
+            section_name = b(section_name_len)
+            if section_name.endswith(b'.text'):
+                text_section = section
+        elif cmd == 18:
+            pos += 2 + 4
+            c = u8()
+            pos += c
+        elif cmd == 20: # Group symbol
+            # Example: (cmd=14) 02 00 00 06 63 68 61 6e 67 65 (....change)
+            # ptr += 1; // symbol number
+            # ptr += 2; // type
+            # ptr += *ptr + 1; // symbol name
+            pos += 3
+            name_len = u8()
+            pos += name_len
+        elif cmd == 28:
+            pos += 2
+            c = u8()
+            pos += c
+        elif cmd == 46:
+            pos += 1
+        elif cmd == 48:
+            pos += 2 + 2 + 4
+            c = u8()
+            pos += c
+        elif cmd == 50:
+            pos += 2
+        elif cmd == 52:
+            pos += 2 + 1
+        elif cmd == 54: # "54 : Inc SLD linenum by word X at offset Y"
+            pos += 2 + 2
+        elif cmd == 56:
+            pos += 2 + 4
+        elif cmd == 58:
+            pos += 2 + 4 + 2
+        elif cmd == 60:
+            pos += 2
+        elif cmd == 74: # function start def
+            pos += 2 + 4 + 2 + 4 + 2 + 4 + 2 + 4 + 4
+            c = u8()
+            pos += c
+        elif cmd == 76: # function end def
+            pos += 2 + 4 + 4
+        elif cmd == 78:
+            pos += 2 + 4 + 4
+        elif cmd == 80:
+            pos += 2 + 4 + 4
+        elif cmd == 82:
+            pos += 2 + 4 + 2 + 2 + 4
+            c = u8()
+            pos += c
+        elif cmd == 84:
+            pos += 2 + 4 + 2 + 2 + 4
+            a = u16()
+            for _ in range(a):
+                pos += 4
+            c = u8()
+            pos += c
+            c = u8()
+            pos += c
+        else:
+            print('unknown opcode', cmd, hex(cmd), pos, path, file=sys.stderr)
+            raise Exception('unknown opcode')
+
+    ret = []
+    all_code = b''.join([x[1] for x in code_blocks])
+
+    # sort by offset descending
+    # don't know the size of each xdef so iter reverse
+    xdefs.sort(key=lambda x: x[0], reverse=True)
+
+    for xdef in xdefs:
+        xdef_off, name = xdef
+        found = False
+        segments = []
+
+        for block_idx, (code_pos, code_block, file_off) in reversed(list(enumerate(code_blocks))):
+            # check if it starts in this code block
+            if xdef_off < code_pos or xdef_off >= code_pos + len(code_block):
+                continue
+
+            # handle when code is split across code blocks (take all remaining code after this start block)
+            for code_pos2, code_block2, file_off2 in code_blocks[block_idx+1:]:
+                can_take = len(code_block2)
+                code = all_code[code_pos2:code_pos2+can_take]
+                all_code = all_code[0:code_pos2] + all_code[code_pos2+can_take:]
+                if len(code) == 0:
+                    break
+                segments.append((file_off2, code))
+
+            can_take = len(code_block) - (xdef_off - code_pos)
+            code = all_code[xdef_off:xdef_off+can_take]
+            assert len(code) > 0
+            all_code = all_code[0:xdef_off] + all_code[xdef_off+can_take:]
+
+            xdef_file_off = file_off + (xdef_off - code_pos)
+            segments.append((xdef_file_off, code))
+
+            # sort segments by offset ascending
+            segments.sort(key=lambda x: x[0])
+            ret.append((name, segments))
+
+            found = True
+            break
+
+        if not found:
+            raise Exception('couldnt locate xdef in obj: {} {}'.format(name, path))
+
+    # sort funcs by offset ascending
+    ret.sort(key=lambda x: x[1][0])
+
+    return ret

--- a/psx_seq_player/build/requirements.txt
+++ b/psx_seq_player/build/requirements.txt
@@ -1,0 +1,8 @@
+ninja
+colorama
+termcolor
+capstone
+iterfzf
+pyperclip
+Jinja2
+levenshtein

--- a/psx_seq_player/lib_snd.cpp
+++ b/psx_seq_player/lib_snd.cpp
@@ -1,8 +1,13 @@
 #include "lib_snd.hpp"
 #include "lib_spu.hpp"
 
+#ifdef PSX
+#include <STDIO.H> // printf
+#include <SYS/TYPES.H>
+#else
 #include <stdio.h> // printf
 #include <sys/types.h>
+#endif
 //#include <libetc.h> // ResetCallback
 #include "psx_stubs.hpp"
 

--- a/psx_seq_player/lib_spu.cpp
+++ b/psx_seq_player/lib_spu.cpp
@@ -1,10 +1,16 @@
 #include "lib_spu.hpp"
 
-#include <sys/types.h>
+#ifdef PSX
+#include <SYS/TYPES.H>
 //#include <libapi.h>
 //#include <libetc.h> // ResetCallBack
+#include <STDARG.H> // va_list
+#include <STDIO.H> // printf
+#else
+#include <sys/types.h>
 #include <stdarg.h> // va_list
 #include <stdio.h> // printf
+#endif
 #include "psx_stubs.hpp"
 
 extern "C"

--- a/psx_seq_player/main.cpp
+++ b/psx_seq_player/main.cpp
@@ -1,4 +1,9 @@
+
+#ifdef PSX
+#include <SYS/TYPES.H>
+#else
 #include <sys/types.h>
+#endif
 #include "lib_snd.hpp"
 #include "lib_spu.hpp"
 #include "Sound.hpp"
@@ -8,11 +13,13 @@
 #include "miseq.bsq.h"
 #include "SeqChunkParser.hpp"
 
+#ifdef PSX
+#include <STDLIB.H>
+#else
 #include <stdlib.h>
+#endif
 
-#define USE_EMU
-
-#ifdef USE_EMU
+#ifndef PSX
 #include "../mednafen/spu.h"
 #include "../mednafen/dma.h"
 
@@ -123,6 +130,11 @@ int main(int, char**)
         MDFN_IEN_PSX::DMA_Update(0);
 
     }*/
+#else
+
+Sound gSound;
+SeqChunkParser gChunkParser;
+
 #endif
 
     gSound.Init();

--- a/psx_seq_player/psx_stubs.hpp
+++ b/psx_seq_player/psx_stubs.hpp
@@ -4,8 +4,8 @@
 // #define PSX
 
 #ifdef PSX
-    #include <libapi.h>
-    #include <libetc.h> // ResetCallBack
+    #include <LIBAPI.H>
+    #include <LIBETC.H> // ResetCallBack
 
 inline void SetSpuReg(volatile u32* pReg, u32 value)
 {

--- a/psx_seq_player/vs_vtc.c
+++ b/psx_seq_player/vs_vtc.c
@@ -1,5 +1,8 @@
 #include "lib_spu.hpp"
 
+#ifdef __cplusplus
+extern "C" 
+#endif
 short SsVabTransCompleted(short immediateFlag)
 {
     long ret = SpuIsTransferCompleted(immediateFlag);


### PR DESCRIPTION
This takes the build system from the MGS decomp so that we can have an easy-to-set-up PSX build on non-windows systems. Usage is like this:

```
git clone https://github.com/sozud/psyq_sdk.git
cd psx_seq_player/build && pip3 install -r requirements.txt && python3 build.py --psyq_path ../../psyq_sdk
```

I had to make some changes to the psyq repo to make this build. I haven't tested this system on windows, if there's a windows-based dev I can look into it. It would probably just need some random path fixes and disabling wine.

I think some of the scripts like hash_include_msvc_formatter.py can probably be removed but I figured this is clean enough for a first pass.

I checked the executable, obj/sound.exe in Mednafen and I heard music, so I think things are working. We can skip the iso building step since Mednafen is able to parse PSX-EXEs.

Having both Cmake and ninja-based builds in the same project is sort of odd but PSY-Q is pretty finicky so I figured going with something that is already functioning makes sense.

I think the reverse engineered libsnd/libspu isn't PSY-Q 4.4 like the compilers/headers are but that doesn't seem to be causing any problems.